### PR TITLE
Allow unicode version strings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def get_package_version(package):
     version = []
     for version_attr in ('version', 'VERSION', '__version__'):
         if hasattr(package, version_attr) \
-                and isinstance(getattr(package, version_attr), str):
+                and isinstance(getattr(package, version_attr), (str, unicode)):
             version_info = getattr(package, version_attr, '')
             for part in re.split('\D+', version_info):
                 try:


### PR DESCRIPTION
Pandas stores the package version in a Unicode string, which was throwing an error from `get_package_version` despite an adequate pandas installation. The fix is to allow vanilla strings as well as Unicode strings through the check, so installation can proceed.
