### PR TITLE
Python 3 compatibility & data packaging fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include *.txt
+recursive-include speleopy/data *.txt

--- a/speleopy/__init__.py
+++ b/speleopy/__init__.py
@@ -15,6 +15,10 @@ __all__ = ['AgeModel',
            'join_records',
            'get_sealevel_data']
 
+# Find package and data directories
+import os.path
+_pkg_dir = os.path.abspath(os.path.dirname(__file__))
+data_dir = os.path.join(_pkg_dir, 'data')
 
 from .damp import AgeModel
 

--- a/speleopy/damp.py
+++ b/speleopy/damp.py
@@ -1,4 +1,5 @@
 from __future__ import division, print_function, absolute_import
+
 import numpy as np
 from scipy.interpolate import interp1d
 from scipy.interpolate import PchipInterpolator

--- a/speleopy/record_class.py
+++ b/speleopy/record_class.py
@@ -1,6 +1,7 @@
 from __future__ import division, print_function
-import pandas as pd
+
 import numpy as np
+import pandas as pd
 
 
 def icevol_corr_prep(record, agelabel, age_in_ky):
@@ -96,7 +97,7 @@ def icevolume_correction(record, target, newlabel, sealevel_data,
         convert_d18o(record, newlabel, newlabel+' (VPDB)', vsmow2vpdb=True)
 
 
-def join_records(record_list, record_names, separator_name='hiatus', 
+def join_records(record_list, record_names, separator_name='hiatus',
                  **concat_kw):
     """
     Put distinct records in the same DataFrame separated by rows of NaNs.

--- a/speleopy/sealevel.py
+++ b/speleopy/sealevel.py
@@ -1,8 +1,11 @@
-import pandas as pd
-import numpy as np
-from scipy.interpolate import interp1d
+from __future__ import print_function, division
+
 import os
-import record_class as rc
+import numpy as np
+import pandas as pd
+from scipy.interpolate import interp1d
+
+from . import data_dir
 
 
 def get_sealevel_data(interpolation='linear'):
@@ -19,9 +22,7 @@ def get_sealevel_data(interpolation='linear'):
         sea level data.
 
     """
-    path, _ = os.path.split(rc.__file__)
-
-    sealevel_file = os.path.join(path, 'data/sealevel.txt')
+    sealevel_file = os.path.join(data_dir, 'sealevel.txt')
 
     with open(sealevel_file) as sealevel:
         contents = sealevel.readlines()


### PR DESCRIPTION
This fixes the package with a different, Python 3-compatible method to determine the path of the data directory.

Also, upon checking the pip installed version it was clear the isotope data wasn't being included for distribution. This PR also introduces a MANIFEST.in file at package root, which will properly package all files matching `speleopy/data/*.txt` when `python setup.py sdist` is called.
